### PR TITLE
Add a manpage

### DIFF
--- a/simarrange.1
+++ b/simarrange.1
@@ -1,0 +1,107 @@
+.TH SIMARRANGE 1 19/10/2013 "User Commands"
+.SH NAME
+simarrange - STL 2D plate packer with collision simulation
+.SH SYNOPSIS
+.B simarrange
+.RB [\| \-x
+.IR WIDTH \|]
+.RB [\| \-y
+.IR HEIGHT \|]
+.RB [\| \-c \|]
+.RB [\| \-m \|]
+.RB [\| \-s
+.IR SPACING \|]
+.RB [\| \-r
+.IR ROTSTEP \|]
+.RB [\| \-p
+.IR POSSTEP \|]
+.RB [\| \-n
+.IR PATH+N \|]
+.RB [\| \-o
+.IR OUTDIR \|]
+.RB [\| \-d \|]
+.RB [\| \-j
+.IR THREADS \|]
+.RB [\| \-q \|]
+.SH DESCRIPTION
+Simarrange is a program that simulates collisions between STL meshes in 2D in order to generate tightly packed sets of parts.
+It takes a directory of STL files as input and outputs STL files with combined plates of parts.
+The parts are assumed to be in the correct printable orientation already.
+.SH OPTIONS
+.TP 5
+.B -x --width
+x dimension of build plate in mm, default 200, must be a positive integer
+.TP
+.B -y --height
+y dimension of build plate in mm, default 200, must be a positive integer
+.TP
+.B -c --circle
+build plate is circular, with diameter given by -x
+.TP
+.B -m --middle
+place first part in the middle of the plate, and pack around it (slower)
+.TP
+.B -s --spacing
+minimal spacing between parts, in mm, default 1, must be a positive integer
+.TP
+.B -r --rotstep
+rotational granularity of search space in degrees, default 10 (reduce for tighter, slower packing)
+.TP
+.B -p --posstep
+positional granularity of search space in mm, default 5 (reduce for tighter, slower packing)
+.TP
+\fB\-n \-\-repeat \fP\fIPATH\fP+\fIN\fP
+add N copies of the file at PATH (or if path is a directory, of the files in that directory) to the plate job
+.TP
+.B -o --outputdir
+output directory, default "."
+.TP
+.B -d --dryrun
+only do a dry run, computing placement but not producing any output file
+.TP
+.B -j --threads
+how many threads to use. Default is as many as possible, set to 1 for single-threaded operation
+.TP
+.B -q --quiet
+output as little noise as possible on stdout
+.SH EXAMPLES
+.TP 5
+.B simarrange -x 200 -y 150 -o output input
+Convert all files from the directory "input" into plates of size 200x150mm and save to directory "output", creating it if necessary
+.TP
+.B simarrange -x 179 -c input
+Convert all files from the directory "input" into circular plates of 170mm diameter and save to directory "output", creating it if necessary
+.TP
+.B simarrange -s 10 input
+Convert all files from the directory "input" into plates of size 200x200mm with 10mm spacing between parts
+.TP
+.B simarrange -m input
+Convert all files from the directory "input" into plates of size 200x200mm, packing from the middle
+.TP
+.B simarrange -n input+10 -n input2+10
+Convert all files from the directories "input" and "input2" into plates of size 200x200mm,
+with 10 copies of each object
+.TP
+.B simarrange -x60 -y60 -s3 blah -p 2
+Convert all files from the directory "blah" into plates of size 60x60mm with 3mm spacing between parts and 2mm search grid
+.TP
+.B simarrange file1.stl file1.stl file2.stl file2.stl file2.stl file2.stl
+Place two copies of file1.stl and four copies of file2.stl into plates of size 200x200mm
+.TP
+.B simarrange input file1.stl file1.stl file2.stl file2.stl file2.stl file2.stl
+Place all STL files in the directory "input" as well as two copies of file1.stl and four copies of file2.stl into plates of size 200x200mm
+.SH COPYRIGHT
+Copyright (c) 2013 Kliment Yanev
+
+Simarrange is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
All the information in the manual page is copy pasted from Readme.
When any of the command line options are changed in the future, you can
update the info in the manpage and simply copy-paste it to the readme once
shown using man.
I've used simarrange as a command name, as it is easier to replace simarrange
wit sa, than to replace sa with simarrange.
sa is also used by psacct.
