### PR TITLE
Include math.h

### DIFF
--- a/simarrange.c
+++ b/simarrange.c
@@ -26,6 +26,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <ctype.h>
 #include <string.h>
 #include <limits.h>
+#include <math.h>
 #include <omp.h>
 
 


### PR DESCRIPTION
To avoid "incompatible implicit declaration of built-in function"

```
simarrange.c: In function ‘sqspiral’:
simarrange.c:59:14: warning: implicit declaration of function ‘sqrt’ [-Wimplicit-function-declaration]
   double x = sqrt(n+1);
              ^~~~
simarrange.c:59:14: warning: incompatible implicit declaration of built-in function ‘sqrt’
simarrange.c:59:14: note: include ‘<math.h>’ or provide a declaration of ‘sqrt’
simarrange.c:60:12: warning: implicit declaration of function ‘floor’ [-Wimplicit-function-declaration]
   int xi = floor(x);
            ^~~~~
simarrange.c:60:12: warning: incompatible implicit declaration of built-in function ‘floor’
simarrange.c:60:12: note: include ‘<math.h>’ or provide a declaration of ‘floor’
```